### PR TITLE
feat: add o11y, deps types, change docs to patch

### DIFF
--- a/packages/commit-utils-core/__tests__/commit-utils-core.test.js
+++ b/packages/commit-utils-core/__tests__/commit-utils-core.test.js
@@ -9,18 +9,30 @@ describe('commit-utils-core', () => {
         ${'wip'}      | ${false}
         ${'feat'}     | ${true}
         ${'fix'}      | ${true}
-        ${'cr'}       | ${false}
-        ${'style'}    | ${false}
         ${'refactor'} | ${false}
-        ${'perf'}     | ${true}
         ${'docs'}     | ${false}
         ${'test'}     | ${false}
         ${'revert'}   | ${true}
-        ${'build'}    | ${false}
-        ${'ci'}       | ${false}
-        ${'chore'}    | ${false}
+        ${'o11y'}     | ${true}
+        ${'deps'}     | ${true}
     `(
         'commit type $commitType has the correct appearsInChangelog value of $appearsInChangelog',
+        ({ commitType, appearsInChangelog }) => {
+            expect(COMMIT_TYPES[commitType].appearsInChangelog).toEqual(
+                appearsInChangelog,
+            )
+            expect(COMMIT_TYPES[commitType].prefix).toEqual(commitType)
+        },
+    )
+
+    it.each`
+        commitType | appearsInChangelog
+        ${'perf'}  | ${true}
+        ${'build'} | ${false}
+        ${'ci'}    | ${false}
+        ${'chore'} | ${false}
+    `(
+        'LEGACY: commit type $commitType has the correct appearsInChangelog value of $appearsInChangelog',
         ({ commitType, appearsInChangelog }) => {
             expect(COMMIT_TYPES[commitType].appearsInChangelog).toEqual(
                 appearsInChangelog,

--- a/packages/commit-utils-core/src/constants.js
+++ b/packages/commit-utils-core/src/constants.js
@@ -1,27 +1,9 @@
 /* eslint-disable sort-keys */
-const COMMIT_TYPES = {
-    wip: {
-        description: 'Changes that are part of some work in progress',
-        title: 'Work In Progress',
-        prefix: 'wip',
-        groupTitle: 'Work In Progress',
-        appearsInChangelog: false,
-    },
-    feat: {
-        description:
-            'A new feature (NOTE: This will be added to the changelog)',
-        title: 'Features',
-        prefix: 'feat',
-        groupTitle: 'Features',
-        appearsInChangelog: true,
-    },
-    fix: {
-        description: 'A bug fix (NOTE: This will be added to the changelog)',
-        title: 'Bug Fixes',
-        prefix: 'fix',
-        groupTitle: 'Bug Fixes',
-        appearsInChangelog: true,
-    },
+
+/**
+ * These legacy types will be removed in a future breaking change.
+ */
+const LEGACY_COMMIT_TYPES = {
     cr: {
         description: 'Changes resulting from code review',
         title: 'Code Reviews',
@@ -37,40 +19,12 @@ const COMMIT_TYPES = {
         groupTitle: 'Styling',
         appearsInChangelog: false,
     },
-    refactor: {
-        description: 'Changes that neither fix a bug nor add a feature',
-        title: 'Code Refactoring',
-        prefix: 'refactor',
-        groupTitle: 'Refactoring',
-        appearsInChangelog: false,
-    },
     perf: {
         description:
             'Changes that improve performance (NOTE: This will be added to the changelog)',
         title: 'Performance Improvements',
         prefix: 'perf',
         groupTitle: 'Performance Improvements',
-        appearsInChangelog: true,
-    },
-    docs: {
-        description: 'Changes to documentation only',
-        title: 'Documentation',
-        prefix: 'docs',
-        groupTitle: 'Documentation',
-        appearsInChangelog: false,
-    },
-    test: {
-        description: 'Adding missing tests or correcting existing tests',
-        title: 'Tests',
-        prefix: 'test',
-        groupTitle: 'Tests',
-        appearsInChangelog: false,
-    },
-    revert: {
-        description: 'Reverts a previous commit AHHHH',
-        title: 'Reverts',
-        prefix: 'revert',
-        groupTitle: 'Reverts',
         appearsInChangelog: true,
     },
     build: {
@@ -95,6 +49,79 @@ const COMMIT_TYPES = {
         groupTitle: 'Chores',
         appearsInChangelog: false,
     },
+}
+
+const COMMIT_TYPES = {
+    feat: {
+        description: 'A new feature, a new export, new component, utils, etc.',
+        title: 'Features',
+        prefix: 'feat',
+        groupTitle: 'Features',
+        appearsInChangelog: true,
+    },
+    fix: {
+        description:
+            'A bug fix which does not affect the public API. This includes performance and accessibility fixes.',
+        title: 'Bug Fixes',
+        prefix: 'fix',
+        groupTitle: 'Bug Fixes',
+        appearsInChangelog: true,
+    },
+    deps: {
+        description:
+            'Dependency updates that affect public consumption of the package (i.e. package.json changes, not devDep changes).',
+        title: 'Dependencies',
+        prefix: 'deps',
+        groupTitle: 'Dependencies',
+        appearsInChangelog: true,
+    },
+    o11y: {
+        description: 'Monitoring, observability, and analytics.',
+        title: 'Observability & Analytics',
+        groupTitle: 'Observability & Analytics',
+        prefix: 'o11y',
+        appearsInChangelog: true,
+    },
+    refactor: {
+        description:
+            "Changes to the internals of a package to make it easier to maintain. No public API. Doesn't affect versions at all.",
+        title: 'Code Refactoring',
+        prefix: 'refactor',
+        groupTitle: 'Refactoring',
+        appearsInChangelog: false,
+    },
+    docs: {
+        description:
+            'Improvements to documentation, including docstring enhancements.',
+        title: 'Documentation',
+        prefix: 'docs',
+        groupTitle: 'Documentation',
+        appearsInChangelog: false,
+    },
+    test: {
+        description:
+            'Modifications to test files. No impact to the public API.',
+        title: 'Tests',
+        prefix: 'test',
+        groupTitle: 'Tests',
+        appearsInChangelog: false,
+    },
+    revert: {
+        description: 'Reverts a previous commit.',
+        title: 'Reverts',
+        prefix: 'revert',
+        groupTitle: 'Reverts',
+        appearsInChangelog: true,
+    },
+    wip: {
+        description:
+            'Changes that are part of some work in progress. This sort of message can exist on a feature branch but should not be merged to the main branch.',
+        title: 'Work In Progress',
+        prefix: 'wip',
+        groupTitle: 'Work In Progress',
+        appearsInChangelog: false,
+    },
+    ...LEGACY_COMMIT_TYPES,
 }
 
 module.exports = {

--- a/packages/conventional-changelog-config/src/commitTypes.js
+++ b/packages/conventional-changelog-config/src/commitTypes.js
@@ -8,7 +8,11 @@ const changelogCommitTypes = commitTypes.filter(
     ({ appearsInChangelog }) => appearsInChangelog,
 )
 
-const PATCH_TYPES = ['fix', 'perf']
+// Legacy patch types will be removed in a future breaking change.
+const LEGACY_PATCH_TYPES = ['perf']
+
+const PATCH_TYPES = ['fix', 'docs', 'deps', 'o11y', ...LEGACY_PATCH_TYPES]
+
 const FEATURE_TYPES = ['feat']
 
 const STRATEGY = {


### PR DESCRIPTION
# Changes

## Deprecated

- perf: This is now merged into “fix” as performance problems can be considered bugs.
- build: The semantic commits only apply to individual packages. If a commit only impacts the root level workspace with no impact on individual packages, for example an infrastructure change, semantic commits do not need to be followed. This requires a change to how commit watch is run.
- ci: Same as build. Semantic commits only affect individual packages.
- style: This has been merged into “refactor”, i.e. linting changes.
- cr: Merged into wip (or refactor).

## Added

- deps: To capture non-dev dependency updates.
- o11y: To capture changes to a package that don’t impact functionality. No user impact but still engineering impact.

## Strategy Changes

- docs: Now produces a patch as we consider documentation part of the API.
